### PR TITLE
Remove binary file and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@ default: build
 .PHONY : build build-static test install-lint-deps lint go-test fmt fmtcheck verify-vendor verify create-release-files release
 
 build:
-	@$(GO) build .
+	@echo Building
+	$(shell mkdir -p ./bin)
+	@$(GO) build -o bin/$(GARM_PROVIDER_NAME) .
+	@echo Binaries are available in $(PWD)/bin
 
 clean: ## Clean up build artifacts
 	@rm -rf ./bin ./build ./release


### PR DESCRIPTION
While updating to `garm-provider-lxd` 0.1.1 I noticed that the repo contains a binary file for version 0.1.0 (which I assume was accidentally committed). This PR removes that file again.

Also I noticed that we build to the repos root directory, instead of `bin/`, which is already in `.gitignore` and also covered by `make clean`. So the binaries will now be build in `bin/`. Alternatively we could add `garm-provider-lxd` to `.gitignore`...

